### PR TITLE
Fix withCourses

### DIFF
--- a/frontend/src/app/course/withCourses.jsx
+++ b/frontend/src/app/course/withCourses.jsx
@@ -27,7 +27,7 @@ const withCourses = <T: *>(
         render() {
             const { loading, courses } = this.props;
             if (!loading && courses) {
-                return React.createElement(component);
+                return React.createElement(component, { courses });
             }
             return <SuspenseFallback />;
         }


### PR DESCRIPTION
Component did not pass down the list of courses, causing the list to be empty even though `courses` were present in state.